### PR TITLE
feat: integrate with case management

### DIFF
--- a/src/main/java/sysint/complaint/workflow/Application.java
+++ b/src/main/java/sysint/complaint/workflow/Application.java
@@ -1,15 +1,15 @@
-package com.example.workflow;
+package sysint.complaint.workflow;
 
-import com.example.workflow.delegate.AutoValidateComplaint;
-import com.example.workflow.delegate.SendAutoResponse;
-import com.example.workflow.delegate.SendRejectionEmail;
-import com.example.workflow.delegate.SendResponseEmail;
-import com.example.workflow.service.impl.ComplaintServiceImpl;
-import com.example.workflow.service.impl.EmailServiceImpl;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
+import sysint.complaint.workflow.delegate.AutoValidateComplaint;
+import sysint.complaint.workflow.delegate.SendAutoResponse;
+import sysint.complaint.workflow.delegate.SendRejectionEmail;
+import sysint.complaint.workflow.delegate.SendResponseEmail;
+import sysint.complaint.workflow.service.impl.ComplaintServiceImpl;
+import sysint.complaint.workflow.service.impl.EmailServiceImpl;
 
 @SpringBootApplication
 public class Application {

--- a/src/main/java/sysint/complaint/workflow/delegate/AutoValidateComplaint.java
+++ b/src/main/java/sysint/complaint/workflow/delegate/AutoValidateComplaint.java
@@ -1,9 +1,9 @@
-package com.example.workflow.delegate;
+package sysint.complaint.workflow.delegate;
 
-import com.example.workflow.service.impl.ComplaintServiceImpl;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.springframework.beans.factory.annotation.Autowired;
+import sysint.complaint.workflow.service.impl.ComplaintServiceImpl;
 
 public class AutoValidateComplaint implements JavaDelegate {
     @Autowired

--- a/src/main/java/sysint/complaint/workflow/delegate/SendAutoResponse.java
+++ b/src/main/java/sysint/complaint/workflow/delegate/SendAutoResponse.java
@@ -1,10 +1,10 @@
-package com.example.workflow.delegate;
+package sysint.complaint.workflow.delegate;
 
-import com.example.workflow.model.EmailDataDTO;
-import com.example.workflow.service.impl.EmailServiceImpl;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.springframework.beans.factory.annotation.Autowired;
+import sysint.complaint.workflow.model.EmailDataDTO;
+import sysint.complaint.workflow.service.impl.EmailServiceImpl;
 
 public class SendAutoResponse implements JavaDelegate {
 

--- a/src/main/java/sysint/complaint/workflow/delegate/SendRejectionEmail.java
+++ b/src/main/java/sysint/complaint/workflow/delegate/SendRejectionEmail.java
@@ -1,10 +1,10 @@
-package com.example.workflow.delegate;
+package sysint.complaint.workflow.delegate;
 
-import com.example.workflow.model.EmailDataDTO;
-import com.example.workflow.service.impl.EmailServiceImpl;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.springframework.beans.factory.annotation.Autowired;
+import sysint.complaint.workflow.model.EmailDataDTO;
+import sysint.complaint.workflow.service.impl.EmailServiceImpl;
 
 public class SendRejectionEmail implements JavaDelegate {
 

--- a/src/main/java/sysint/complaint/workflow/delegate/SendResponseEmail.java
+++ b/src/main/java/sysint/complaint/workflow/delegate/SendResponseEmail.java
@@ -1,10 +1,10 @@
-package com.example.workflow.delegate;
+package sysint.complaint.workflow.delegate;
 
-import com.example.workflow.model.EmailDataDTO;
-import com.example.workflow.service.impl.EmailServiceImpl;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.springframework.beans.factory.annotation.Autowired;
+import sysint.complaint.workflow.model.EmailDataDTO;
+import sysint.complaint.workflow.service.impl.EmailServiceImpl;
 
 public class SendResponseEmail  implements JavaDelegate {
 

--- a/src/main/java/sysint/complaint/workflow/model/ComplaintDTO.java
+++ b/src/main/java/sysint/complaint/workflow/model/ComplaintDTO.java
@@ -1,4 +1,4 @@
-package com.example.workflow.model;
+package sysint.complaint.workflow.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/sysint/complaint/workflow/model/EmailDataDTO.java
+++ b/src/main/java/sysint/complaint/workflow/model/EmailDataDTO.java
@@ -1,4 +1,4 @@
-package com.example.workflow.model;
+package sysint.complaint.workflow.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/sysint/complaint/workflow/service/ComplaintService.java
+++ b/src/main/java/sysint/complaint/workflow/service/ComplaintService.java
@@ -1,4 +1,4 @@
-package com.example.workflow.service;
+package sysint.complaint.workflow.service;
 
 public interface ComplaintService {
     public  boolean validate(String complaint) ;

--- a/src/main/java/sysint/complaint/workflow/service/EmailService.java
+++ b/src/main/java/sysint/complaint/workflow/service/EmailService.java
@@ -1,6 +1,7 @@
-package com.example.workflow.service;
+package sysint.complaint.workflow.service;
 
-import com.example.workflow.model.EmailDataDTO;
+
+import sysint.complaint.workflow.model.EmailDataDTO;
 
 public interface EmailService {
 

--- a/src/main/java/sysint/complaint/workflow/service/impl/ComplaintServiceImpl.java
+++ b/src/main/java/sysint/complaint/workflow/service/impl/ComplaintServiceImpl.java
@@ -1,6 +1,6 @@
-package com.example.workflow.service.impl;
+package sysint.complaint.workflow.service.impl;
 
-import com.example.workflow.service.ComplaintService;
+import sysint.complaint.workflow.service.ComplaintService;
 
 public class ComplaintServiceImpl implements ComplaintService {
     @Override

--- a/src/main/java/sysint/complaint/workflow/service/impl/EmailServiceImpl.java
+++ b/src/main/java/sysint/complaint/workflow/service/impl/EmailServiceImpl.java
@@ -1,16 +1,14 @@
-package com.example.workflow.service.impl;
+package sysint.complaint.workflow.service.impl;
 
-import com.example.workflow.model.EmailDataDTO;
-import com.example.workflow.service.EmailService;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
-
-import java.util.ArrayList;
-import java.util.List;
+import sysint.complaint.workflow.model.EmailDataDTO;
+import sysint.complaint.workflow.service.EmailService;
 
 public class EmailServiceImpl implements EmailService {
     @Autowired

--- a/src/main/resources/process.bpmn
+++ b/src/main/resources/process.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0fr9mxs" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0fr9mxs" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0">
   <bpmn:process id="NewComplainReciveProcess" name="New Complain Recive Process" isExecutable="true" camunda:versionTag="1.0.4">
     <bpmn:startEvent id="StartEvent_1" name="User wants to complain">
       <bpmn:outgoing>SequenceFlow_1fp17al</bpmn:outgoing>
@@ -72,12 +72,8 @@
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_0dkxu9c" sourceRef="send_reasponse" targetRef="Event_06pp7ka" />
     <bpmn:sequenceFlow id="Flow_1jbaw7i" sourceRef="complaint_autovalidation" targetRef="Gateway_19yvxv4" />
-    <bpmn:userTask id="review_complaint" name="Review Complaint">
-      <bpmn:extensionElements>
-        <camunda:formData>
-          <camunda:formField id="review_reult" label="Case action" type="string" defaultValue="solve" />
-        </camunda:formData>
-      </bpmn:extensionElements>
+    <bpmn:userTask id="review_complaint" name="Review Complaint" camunda:formKey="camunda-forms:/forms/human_review.form">
+      <bpmn:extensionElements />
       <bpmn:incoming>Flow_1vq88xs</bpmn:incoming>
       <bpmn:outgoing>Flow_0ieak00</bpmn:outgoing>
     </bpmn:userTask>
@@ -105,28 +101,93 @@
       <bpmn:incoming>Flow_0ydbsjq</bpmn:incoming>
       <bpmn:outgoing>Flow_0dkxu9c</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="open_new_case" name="Open New Unsolved Case" camunda:formKey="camunda-forms:/forms/case_response.form">
+    <bpmn:serviceTask id="open_new_case" name="Open New Unsolved Case" camunda:type="external" camunda:topic="createCase">
       <bpmn:incoming>opens_new_case</bpmn:incoming>
       <bpmn:outgoing>Flow_1kfx625</bpmn:outgoing>
-    </bpmn:userTask>
-    <bpmn:userTask id="add_to_existing_case" name="Add Complaint to Existing Case" camunda:formKey="camunda-forms:/forms/case_response.form">
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="add_to_existing_case" name="Add Complaint to Existing Case" camunda:type="external" camunda:topic="addToCase">
       <bpmn:incoming>adds_to_case</bpmn:incoming>
       <bpmn:outgoing>Flow_0zdcez4</bpmn:outgoing>
-    </bpmn:userTask>
-    <bpmn:userTask id="open_and_solve_case" name="Open New Solved Case" camunda:formKey="camunda-forms:/forms/case_response.form">
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="open_and_solve_case" name="Open New Solved Case" camunda:type="external" camunda:topic="createCase">
       <bpmn:incoming>solves_case</bpmn:incoming>
       <bpmn:outgoing>Flow_0qirlsj</bpmn:outgoing>
-    </bpmn:userTask>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="NewComplainReciveProcess">
-      <bpmndi:BPMNEdge id="Flow_1pxe5ci_di" bpmnElement="Flow_1pxe5ci">
-        <di:waypoint x="350" y="117" />
-        <di:waypoint x="380" y="117" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="163" y="142" width="68" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_03q8cyf_di" bpmnElement="add_contact_data">
+        <dc:Bounds x="250" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1vb16ue_di" bpmnElement="send_complaint">
+        <dc:Bounds x="380" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_19yvxv4_di" bpmnElement="Gateway_19yvxv4" isMarkerVisible="true">
+        <dc:Bounds x="635" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1x8n2v5_di" bpmnElement="Event_1x8n2v5">
+        <dc:Bounds x="872" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="846" y="142" width="89" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_18q6scn_di" bpmnElement="Gateway_0npn2to">
+        <dc:Bounds x="635" y="235" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0gfj7za_di" bpmnElement="Gateway_0gm1cqi">
+        <dc:Bounds x="875" y="285" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ztbbrb_di" bpmnElement="complaint_autovalidation">
+        <dc:Bounds x="510" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_06pp7ka_di" bpmnElement="Event_06pp7ka">
+        <dc:Bounds x="1592" y="292" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1585" y="335" width="51" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05m0t3t_di" bpmnElement="review_complaint">
+        <dc:Bounds x="730" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hhua9e_di" bpmnElement="send_rejection_email">
+        <dc:Bounds x="730" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mvtbb2_di" bpmnElement="send_auto_response">
+        <dc:Bounds x="730" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0pu1xd7_di" bpmnElement="Gateway_07v5uzl" isMarkerVisible="true">
+        <dc:Bounds x="975" y="285" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1c0gg4b_di" bpmnElement="Gateway_0qigol5" isMarkerVisible="true">
+        <dc:Bounds x="1265" y="285" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ejj2p9_di" bpmnElement="send_reasponse">
+        <dc:Bounds x="1400" y="270" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mgmeb4_di" bpmnElement="open_new_case">
+        <dc:Bounds x="1080" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0zp0xl6_di" bpmnElement="add_to_existing_case">
+        <dc:Bounds x="1090" y="270" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0j75z4q_di" bpmnElement="open_and_solve_case">
+        <dc:Bounds x="1080" y="380" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_1fp17al_di" bpmnElement="SequenceFlow_1fp17al">
         <di:waypoint x="215" y="117" />
         <di:waypoint x="250" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1pxe5ci_di" bpmnElement="Flow_1pxe5ci">
+        <di:waypoint x="350" y="117" />
+        <di:waypoint x="380" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0t07lb6_di" bpmnElement="Flow_0t07lb6">
         <di:waypoint x="480" y="117" />
@@ -169,16 +230,16 @@
         <di:waypoint x="900" y="260" />
         <di:waypoint x="900" y="285" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0tgjb45_di" bpmnElement="adds_to_case">
+        <di:waypoint x="1025" y="310" />
+        <di:waypoint x="1090" y="310" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1024" y="292" width="68" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ob2dm2_di" bpmnElement="Flow_1ob2dm2">
         <di:waypoint x="925" y="310" />
         <di:waypoint x="975" y="310" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0tgjb45_di" bpmnElement="adds_to_case">
-        <di:waypoint x="1025" y="310" />
-        <di:waypoint x="1080" y="310" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1019" y="292" width="68" height="14" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1o7y2o5_di" bpmnElement="solves_case">
         <di:waypoint x="1000" y="335" />
@@ -207,7 +268,7 @@
         <di:waypoint x="1290" y="285" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0zdcez4_di" bpmnElement="Flow_0zdcez4">
-        <di:waypoint x="1180" y="310" />
+        <di:waypoint x="1190" y="310" />
         <di:waypoint x="1265" y="310" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ydbsjq_di" bpmnElement="Flow_0ydbsjq">
@@ -222,71 +283,6 @@
         <di:waypoint x="610" y="117" />
         <di:waypoint x="635" y="117" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="163" y="142" width="68" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_03q8cyf_di" bpmnElement="add_contact_data">
-        <dc:Bounds x="250" y="77" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1vb16ue_di" bpmnElement="send_complaint">
-        <dc:Bounds x="380" y="77" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_19yvxv4_di" bpmnElement="Gateway_19yvxv4" isMarkerVisible="true">
-        <dc:Bounds x="635" y="92" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1x8n2v5_di" bpmnElement="Event_1x8n2v5">
-        <dc:Bounds x="872" y="99" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="846" y="142" width="89" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0gfj7za_di" bpmnElement="Gateway_0gm1cqi">
-        <dc:Bounds x="875" y="285" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_18q6scn_di" bpmnElement="Gateway_0npn2to">
-        <dc:Bounds x="635" y="235" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_06pp7ka_di" bpmnElement="Event_06pp7ka">
-        <dc:Bounds x="1592" y="292" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1585" y="335" width="51" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0ztbbrb_di" bpmnElement="complaint_autovalidation">
-        <dc:Bounds x="510" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_05m0t3t_di" bpmnElement="review_complaint">
-        <dc:Bounds x="730" y="320" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0hhua9e_di" bpmnElement="send_rejection_email">
-        <dc:Bounds x="730" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0mvtbb2_di" bpmnElement="send_auto_response">
-        <dc:Bounds x="730" y="220" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0pu1xd7_di" bpmnElement="Gateway_07v5uzl" isMarkerVisible="true">
-        <dc:Bounds x="975" y="285" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1c0gg4b_di" bpmnElement="Gateway_0qigol5" isMarkerVisible="true">
-        <dc:Bounds x="1265" y="285" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0ejj2p9_di" bpmnElement="send_reasponse">
-        <dc:Bounds x="1400" y="270" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1crjz98_di" bpmnElement="open_new_case">
-        <dc:Bounds x="1080" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_104bsa1_di" bpmnElement="add_to_existing_case">
-        <dc:Bounds x="1080" y="270" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0i2uhtx_di" bpmnElement="open_and_solve_case">
-        <dc:Bounds x="1080" y="380" width="100" height="80" />
-      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/static/forms/human_review.form
+++ b/src/main/resources/static/forms/human_review.form
@@ -1,0 +1,73 @@
+{
+  "components": [
+    {
+      "values": [
+        {
+          "label": "solve",
+          "value": "solve"
+        },
+        {
+          "value": "add",
+          "label": "add"
+        },
+        {
+          "value": "new",
+          "label": "new"
+        }
+      ],
+      "label": "Case action",
+      "type": "select",
+      "id": "Field_1pph1yi",
+      "key": "case_action",
+      "defaultValue": "solve",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "values": [
+        {
+          "value": "1",
+          "label": "First case"
+        },
+        {
+          "label": "Second case",
+          "value": "2"
+        }
+      ],
+      "label": "Running cases",
+      "type": "select",
+      "id": "Field_0ev1ijz",
+      "key": "case_id",
+      "disabled": false,
+      "properties": {},
+      "description": "Which case does this belong to"
+    },
+    {
+      "key": "complaint_response_body",
+      "label": "Response",
+      "type": "textfield",
+      "description": "Body of the response to the complaint",
+      "id": "Field_03ierpo",
+      "validate": {
+        "required": true
+      }
+    },
+    {
+      "action": "submit",
+      "key": "button3",
+      "label": "Send",
+      "type": "button",
+      "id": "Field_08r00ud"
+    }
+  ],
+  "type": "default",
+  "id": "Form_0v0n7n9",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.3.0"
+  },
+  "executionPlatform": "Camunda Platform",
+  "executionPlatformVersion": "7.17.0",
+  "schemaVersion": 4
+}


### PR DESCRIPTION
This pr integrates with my case-management service.
It changes what was currently defined as user tasks:
- Open new unsolved case
- Add to existing case
- open new unsolved case

These are now service tasks being performed automatically.

Before the response message was written in each of these user task, so to still allow the cucumber administrator to write a response message, the message was moved to the 'Review Complaint' task, while still keeping all the same id's